### PR TITLE
Fix to get histories

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -70,7 +70,7 @@
     });
   }
 
-  const options = document.querySelectorAll('div.top-controls select option');
+  const options = document.querySelectorAll('form.time-period-chooser select option');
   const promises = [];
   for (const option of options) {
     let m = /year-(\d\d\d\d)/.exec(option.value);


### PR DESCRIPTION
Related to https://github.com/1000ch/amazon-payment-history/issues/1.
If I haven't bought anything for 30 days, `.top-controls` seems not to be used.
I fixed to use `span.a-declarative` instead of it.
Could you check the PR? 
